### PR TITLE
feat: add responsive navbar

### DIFF
--- a/frontend/src/components/HomePage.css
+++ b/frontend/src/components/HomePage.css
@@ -2,29 +2,6 @@
   font-family: Arial, sans-serif;
 }
 
-.navbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem 2rem;
-  background-color: #fff;
-  position: sticky;
-  top: 0;
-  z-index: 10;
-}
-
-.nav-links {
-  list-style: none;
-  display: flex;
-  gap: 1rem;
-  margin: 0;
-  padding: 0;
-}
-
-.nav-links a {
-  text-decoration: none;
-  color: #333;
-}
 
 .hero {
   position: relative;
@@ -123,11 +100,4 @@
   color: #fff;
   margin: 0 0.5rem;
   text-decoration: none;
-}
-
-@media (max-width: 600px) {
-  .nav-links {
-    flex-direction: column;
-    gap: 0.5rem;
-  }
 }

--- a/frontend/src/components/HomePage.jsx
+++ b/frontend/src/components/HomePage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import './HomePage.css';
+import Navbar from './Navbar';
 
 const clubs = [
   { name: 'LPBTYC', region: 'Tunis' },
@@ -35,16 +36,7 @@ const benMembers = [
 function HomePage() {
   return (
     <div className="home-page">
-      <nav className="navbar">
-        <div className="nav-logo">ASSOCIATION DES CLUBS DE JEUNES</div>
-        <ul className="nav-links">
-          <li><a href="#">Accueil</a></li>
-          <li><a href="#">À propos de l'association</a></li>
-          <li><a href="#clubs">Clubs locaux</a></li>
-          <li><a href="#projects">Projets nationaux</a></li>
-          <li><a href="#ben">BEN</a></li>
-        </ul>
-      </nav>
+      <Navbar />
 
       <section className="hero">
         <div className="hero-content">

--- a/frontend/src/components/Navbar.css
+++ b/frontend/src/components/Navbar.css
@@ -1,0 +1,82 @@
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #fff;
+  padding: 0.75rem 1.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.nav-logo {
+  font-weight: bold;
+}
+
+.nav-menu {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.nav-menu a {
+  text-decoration: none;
+  color: #333;
+  font-size: 0.9rem;
+}
+
+.nav-cta {
+  background: #007bff;
+  color: #fff;
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+  transition: background 0.3s;
+}
+
+.nav-cta:hover {
+  background: #0056b3;
+}
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.nav-toggle .bar {
+  width: 25px;
+  height: 3px;
+  background-color: #333;
+  margin: 4px 0;
+}
+
+@media (max-width: 768px) {
+  .nav-menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background: #fff;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 1rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    display: none;
+  }
+
+  .nav-menu.open {
+    display: flex;
+  }
+
+  .nav-cta {
+    width: 100%;
+    text-align: center;
+    margin-top: 0.5rem;
+  }
+
+  .nav-toggle {
+    display: flex;
+  }
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import './Navbar.css';
+
+const Navbar: React.FC = () => {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const toggleMenu = () => setMenuOpen(!menuOpen);
+
+  return (
+    <header className="navbar">
+      <div className="nav-logo">ASSOCIATION YOUTH CLUBs</div>
+      <div className={`nav-menu ${menuOpen ? 'open' : ''}`}>
+        <a href="#">Home</a>
+        <a href="#about">About</a>
+        <a href="#clubs">Local Clubs</a>
+        <a href="#projects">National Projects</a>
+        <a href="#ben">BEN</a>
+        <a href="#signup" className="nav-cta">S’inscrire</a>
+      </div>
+      <button className="nav-toggle" onClick={toggleMenu} aria-label="Toggle navigation">
+        <span className="bar"></span>
+        <span className="bar"></span>
+        <span className="bar"></span>
+      </button>
+    </header>
+  );
+};
+
+export default Navbar;
+


### PR DESCRIPTION
## Summary
- add `Navbar` component with logo, navigation links, and call-to-action button
- style navbar with white background, shadow, and mobile hamburger menu
- replace HomePage inline nav with `Navbar`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892008a531083218d827f2d90067de1